### PR TITLE
update install requirement to scikit-learn (fix)

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -18,7 +18,7 @@ setup(
     python_requires='>=3.6',
     author='Terence Parr, Kerem Turgutlu',
     author_email='parrt@antlr.org, kcturgutlu@dons.usfca.edu',
-    install_requires=['stratx>=0.2','numpy','pandas','sklearn','matplotlib'],
+    install_requires=['stratx>=0.2','numpy','pandas','scikit-learn','matplotlib'],
     description='Permutation and drop-column importance for scikit-learn random forests and other models',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Telling Pip to install `sklearn` does not actually install Scikit-Learn (need to specify `scikit-learn`)