### PR TITLE
Add missing arg to _generate_unsampled_indices

### DIFF
--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -1,10 +1,4 @@
 """
-Attention! This is a slight customized version of rfpimp. The official
-distribution had some functions broken by sklearn 0.22 version. As soon
-as the official version gets fixed up, this file should be removed from
-the project.
-
-
 A simple library of functions that provide feature importances
 for scikit-learn random forest regressors and classifiers.
 

--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -411,15 +411,13 @@ def permutation_importances_raw(rf, X_train, y_train, metric, n_samples=5000):
     return np.array(imp)
 
 
-def _get_unsample_indices(tree, n_samples):
+def _get_unsampled_indices(tree, n_samples):
     """
     An interface to get unsampled indices regardless of sklearn version.
     """
-    # Version 0.21 or older uses only two arguments.
-    try:
+    try:  # Version 0.21 or older uses only two arguments.
         return _generate_unsampled_indices(tree.random_state, n_samples)
-    # Version 0.22 or newer uses only two arguments.
-    except TypeError:
+    except TypeError:  # Version 0.22 or newer uses only two arguments.
         n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, n_samples)
         return _generate_unsampled_indices(
             tree.random_state, n_samples, n_samples_bootstrap
@@ -441,7 +439,7 @@ def oob_classifier_accuracy(rf, X_train, y_train):
     n_classes = len(np.unique(y))
     predictions = np.zeros((n_samples, n_classes))
     for tree in rf.estimators_:
-        unsampled_indices = _get_unsample_indices
+        unsampled_indices = _get_unsampled_indices(tree, n_samples)
         tree_preds = tree.predict_proba(X[unsampled_indices, :])
         predictions[unsampled_indices] += tree_preds
 
@@ -467,7 +465,7 @@ def oob_regression_r2_score(rf, X_train, y_train):
     predictions = np.zeros(n_samples)
     n_predictions = np.zeros(n_samples)
     for tree in rf.estimators_:
-        unsampled_indices = _get_unsample_indices(tree, n_samples)
+        unsampled_indices = _get_unsampled_indices(tree, n_samples)
         tree_preds = tree.predict(X[unsampled_indices, :])
         predictions[unsampled_indices] += tree_preds
         n_predictions[unsampled_indices] += 1

--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.ensemble.forest import _generate_unsampled_indices
+from sklearn.ensemble.forest import _generate_unsampled_indices, _get_n_samples_bootstrap
 from sklearn.ensemble import forest
 from sklearn.model_selection import cross_val_score
 from sklearn.base import clone
@@ -25,7 +25,6 @@ from copy import copy
 import warnings
 import tempfile
 from os import getpid, makedirs
-from stratx.partdep import partial_dependence
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 GREY = '#444443'
@@ -427,7 +426,8 @@ def oob_classifier_accuracy(rf, X_train, y_train):
     n_classes = len(np.unique(y))
     predictions = np.zeros((n_samples, n_classes))
     for tree in rf.estimators_:
-        unsampled_indices = _generate_unsampled_indices(tree.random_state, n_samples)
+        n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, n_samples)
+        unsampled_indices = _generate_unsampled_indices(tree.random_state, n_samples, n_samples_bootstrap)
         tree_preds = tree.predict_proba(X[unsampled_indices, :])
         predictions[unsampled_indices] += tree_preds
 
@@ -453,7 +453,8 @@ def oob_regression_r2_score(rf, X_train, y_train):
     predictions = np.zeros(n_samples)
     n_predictions = np.zeros(n_samples)
     for tree in rf.estimators_:
-        unsampled_indices = _generate_unsampled_indices(tree.random_state, n_samples)
+        n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, n_samples)
+        unsampled_indices = _generate_unsampled_indices(tree.random_state, n_samples, n_samples_bootstrap)
         tree_preds = tree.predict(X[unsampled_indices, :])
         predictions[unsampled_indices] += tree_preds
         n_predictions[unsampled_indices] += 1


### PR DESCRIPTION
Fixes #27 

In sklearn 0.22 `sklearn._forest._generate_unsampled_indices(random_state, n_samples)` changed signature to `sklearn._forest._generate_unsampled_indices(random_state, n_samples, n_samples_bootstrap)`. 

I used the `sklearn._forest._get_n_samples_bootstrap(n_samples, n_samples)` with the same number of samples and passes to the new arg just to avoid raising the exception.