### PR TITLE
Modify sklearn version check to use distutils.version.LooseVersion

### DIFF
--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -27,6 +27,7 @@ import warnings
 import tempfile
 from os import getpid, makedirs
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from distutils.version import LooseVersion
 
 GREY = '#444443'
 
@@ -416,7 +417,7 @@ def _get_unsampled_indices(tree, n_samples):
     """
     An interface to get unsampled indices regardless of sklearn version.
     """
-    if sklearn.__version__.startswith("0.22"):
+    if LooseVersion(sklearn.__version__) >= LooseVersion("0.22"):
         # Version 0.22 or newer uses 3 arguments.
         from sklearn.ensemble.forest import _get_n_samples_bootstrap
         n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, n_samples)


### PR DESCRIPTION
First, thanks for maintaining this package. I know that scikit-learn has now included permutation importance in their library but this package includes some nice quality of life utilities.

This pull request fixes the handling of the version check with sklearn to avoid breakage.

The new sklearn version breaks the version check in the _get_unsampled_indices function. I modified the if statement to use distutils.version.LooseVersion which should be more robust to future changes in sklearn versions. The check works with the current sklearn stable branch (0.23.0) as well as the dev branch (0.24.dev0) naming scheme.

There is also the possibility to use [packaging.version.parse](https://packaging.pypa.io/en/latest/version/#packaging.version.parse) which is compliant with PEP440 but this would introduce a third party dependency and I don't think this would be ideal.