### PR TITLE
Use pandas defaults to generate correlation matrix if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info/
+__pycache__/

--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -18,7 +18,7 @@ from sklearn.ensemble import forest
 from sklearn.model_selection import cross_val_score
 from sklearn.base import clone
 from sklearn.metrics import r2_score
-from scipy.stats import spearmanr
+from scipy import stats
 from pandas.api.types import is_numeric_dtype
 from matplotlib.colors import ListedColormap
 from matplotlib.ticker import FormatStrFormatter
@@ -816,6 +816,17 @@ def plot_dependence_heatmap(D,
     return PimpViz()
 
 
+def get_feature_corr(df, method="spearman"):
+    if isinstance(df, pd.DataFrame):
+        return df.corr(method=method).values
+    elif method == "spearman":
+        return stats.spearmanr(df).correlation
+    elif method == "pearson":
+        return np.corrcoef(df)
+    else:
+        raise ValueError("unsupported correlation method")
+
+
 def feature_corr_matrix(df):
     """
     Return the Spearman's rank-order correlation between all pairs
@@ -832,7 +843,7 @@ def feature_corr_matrix(df):
                      without the target variable.
     :return: a data frame with the correlation matrix
     """
-    corr = np.round(spearmanr(df).correlation, 4)
+    corr = np.round(get_feature_corr(df), 4)
     df_corr = pd.DataFrame(data=corr, index=df.columns, columns=df.columns)
     return df_corr
 
@@ -862,7 +873,7 @@ def plot_corr_heatmap(df,
                       figsize=(7,5), label_fontsize=13, value_fontsize=11)
     viz.view() # or just viz in notebook
     """
-    corr = spearmanr(df).correlation
+    corr = get_feature_corr(df)
     if len(corr.shape) == 0:
         corr = np.array([[1.0, corr],
                          [corr, 1.0]])

--- a/src/rfpimp.py
+++ b/src/rfpimp.py
@@ -861,13 +861,16 @@ def plot_dependence_heatmap(D,
 
 def get_feature_corr(df, method="spearman"):
     if isinstance(df, pd.DataFrame):
-        return df.corr(method=method).values
+        result = df.corr(method=method).values
+    elif callable(method):
+        result = method(df)
     elif method == "spearman":
-        return stats.spearmanr(df).correlation
+        result = stats.spearmanr(df).correlation
     elif method == "pearson":
-        return np.corrcoef(df)
+        result = np.corrcoef(df)
     else:
         raise ValueError("unsupported correlation method")
+    return result
 
 
 def feature_corr_matrix(df):

--- a/src/setup.py
+++ b/src/setup.py
@@ -18,7 +18,7 @@ setup(
     python_requires='>=3.6',
     author='Terence Parr, Kerem Turgutlu',
     author_email='parrt@antlr.org, kcturgutlu@dons.usfca.edu',
-    install_requires=['stratx>=0.2','numpy','pandas','scikit-learn','matplotlib'],
+    install_requires=['numpy','pandas','scikit-learn','matplotlib'],
     description='Permutation and drop-column importance for scikit-learn random forests and other models',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Using default Pandas methods to generate correlation matrices can be much faster in some cases and is also robust to NaNs. I created a small wrapper that falls back to `scipy.stats.spearmanr` if argument is not a Pandas dataframe and also to `np.corrcoef` when Pearson correlation is specified, which also returns a correlation matrix.