### PR TITLE
chore: fixing dash issue for setuptools v78

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fixes issue caused by `-` character in setuptools config detailed here:

https://github.com/pypa/setuptools/issues/4910

`-` character support in `setup.cfg` has been removed in setuptools v78:

https://setuptools.pypa.io/en/latest/history.html#deprecations-and-removals